### PR TITLE
Add focal to debian/changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libglibutil (1.0.55-0ubuntu1) focal; urgency=medium
+
+  * Initial packaging for Focal (Ubuntu)
+
+ -- Rudra Saraswat <rs2009@ubuntu.com>  Sun, 05 Sep 2021 12:07:20 +0530
+
 libglibutil (1.0.55) unstable; urgency=low
 
   * Added gutil_log_dump()


### PR DESCRIPTION
I've added an entry for Ubuntu 20.04 (`focal`) to be able to upload this package to Launchpad.